### PR TITLE
let's have the ORIGRANDGROUP numbers be produced reproducibly

### DIFF
--- a/src/com/winvector/db/LoadFiles.java
+++ b/src/com/winvector/db/LoadFiles.java
@@ -46,7 +46,7 @@ public class LoadFiles {
 		}
 		tableControl.buildSQLStatements();
 		tableControl.createTable(handle);
-		final Random rand = new Random();
+		final Random rand = new Random(42);
 		long nInserted = 0;
 		for(int argi=firstSourceArg;argi<args.length;++argi) {
 			final URI inURI = new URI(args[argi]);


### PR DESCRIPTION
Hi! I'm not an expert in Java, so I'm not sure this fix is complete, but it seems like we should specify seed for the random number generation so that everybody can reproduce results, yes?
